### PR TITLE
Get rid of guava as it is no longer needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
 		<joda-time.version>2.10.10</joda-time.version>
 		<commons-lang.version>2.6</commons-lang.version>
 		<reflections.version>0.9.11</reflections.version>
-		<guava.version>30.1-jre</guava.version>
 		<gentyref.version>1.2.0</gentyref.version>
 		<hamcrest.version>2.2</hamcrest.version>
 		<junit.version>5.7.1</junit.version>
@@ -100,11 +99,6 @@
 			<groupId>org.reflections</groupId>
 			<artifactId>reflections</artifactId>
 			<version>${reflections.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.googlecode.gentyref</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,10 +61,10 @@
 		<project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
 
 		<jacoco.version>0.8.0</jacoco.version>
-		<slf4j-api.version>1.7.30</slf4j-api.version>
+		<slf4j-api.version>1.7.32</slf4j-api.version>
 		<joda-time.version>2.10.10</joda-time.version>
 		<commons-lang.version>2.6</commons-lang.version>
-		<reflections.version>0.9.11</reflections.version>
+		<reflections.version>0.10.2</reflections.version>
 		<gentyref.version>1.2.0</gentyref.version>
 		<hamcrest.version>2.2</hamcrest.version>
 		<junit.version>5.7.1</junit.version>

--- a/src/test/java/com/namics/commons/random/support/BeanUtilsTest.java
+++ b/src/test/java/com/namics/commons/random/support/BeanUtilsTest.java
@@ -41,19 +41,19 @@ class BeanUtilsTest {
 		private String standard;
 		private String extended;
 
-		String getStandard() {
+		public String getStandard() {
 			return standard;
 		}
 
-		void setStandard(String standard) {
+		public void setStandard(String standard) {
 			this.standard = standard;
 		}
 
-		String getExtended() {
+		public String getExtended() {
 			return extended;
 		}
 
-		TestBean setExtended(String extended) {
+		public TestBean setExtended(String extended) {
 			this.extended = extended;
 			return this;
 		}


### PR DESCRIPTION
Guava is used as dependency even though it is not really used.
Further more org.reflections used guava, but in the latest version it is not longer used.
And BeanUtilsTest does currently not work (at least with java 17).